### PR TITLE
fixed percentage formatting

### DIFF
--- a/BigGulp WatchKit Extension/GlanceController.swift
+++ b/BigGulp WatchKit Extension/GlanceController.swift
@@ -13,7 +13,7 @@ class GlanceController: WKInterfaceController {
         super.willActivate()
 
         let entry = EntryHandler().currentEntry() as Entry
-        self.percentageLabel.setText("\(entry.percentage)%")
+        self.percentageLabel.setText(entry.formattedPercentage())
     }
 
     override func didDeactivate() {

--- a/BigGulp WatchKit Extension/InterfaceController.swift
+++ b/BigGulp WatchKit Extension/InterfaceController.swift
@@ -37,7 +37,7 @@ class InterfaceController: WKInterfaceController {
         let percentage = Int(ceil(entry.percentage / 10.0))
         let image = "progress-\(percentage)-watch"
         self.interfaceGroup.setBackgroundImageNamed(image)
-        self.goalLabel.setText("DAILY GOAL: \(entry.percentage)%")
+        self.goalLabel.setText("DAILY GOAL: \(entry.formattedPercentage())")
     }
 
     @IBAction func addMenuAction() {

--- a/BigGulp/Model/Entry.swift
+++ b/BigGulp/Model/Entry.swift
@@ -57,4 +57,10 @@ class Entry: RLMObject {
         self.gulps.removeLastObject()
         realm.commitWriteTransaction()
     }
+    
+    func formattedPercentage() -> String {
+        let percentageFormatter = NSNumberFormatter()
+        percentageFormatter.numberStyle = .PercentStyle
+        return percentageFormatter.stringFromNumber(percentage / 100.0) ?? "\(percentage)%"
+    }
 }

--- a/BigGulp/ViewControllers/CalendarViewController.swift
+++ b/BigGulp/ViewControllers/CalendarViewController.swift
@@ -47,7 +47,7 @@ class CalendarViewController: UIViewController, JTCalendarDataSource {
             if (entry.percentage >= 100) {
                 self.dailyLabel.text = "Goal Met!"
             } else {
-                self.dailyLabel.text = "\(Int(ceil(entry.percentage)))%"
+                self.dailyLabel.text = entry.formattedPercentage()
             }
         } else {
             self.dailyLabel.text = ""


### PR DESCRIPTION
Currently the percentage can get too long and be cut off in Glance: 

![img_2668](https://cloud.githubusercontent.com/assets/1157147/7390916/71f098cc-ee31-11e4-8601-f3de85d315eb.PNG)

This formats the percentage to be a nice, easy to read, whole number: 

![ios simulator screen shot - apple watch apr 29 2015 5 32 18 am](https://cloud.githubusercontent.com/assets/1157147/7390923/81cb0444-ee31-11e4-8b9c-77734322ff8d.png)
