### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Pods/AMPopTip/README.md
+++ b/Pods/AMPopTip/README.md
@@ -18,33 +18,33 @@ This popover can be used to leave subtle hints about your UI and provide fun loo
   </a>
 </p>
 
-#Screenshot
+# Screenshot
 ![AMPopTip](https://raw.githubusercontent.com/andreamazz/AMPopTip/master/assets/screenshot.gif)
 
-#Setup with CocoaPods
+# Setup with CocoaPods
 * Add ```pod 'AMPopTip'``` to your ```Podfile```
 * Run ```pod install```
 * Run ```open App.xcworkspace```
 
-#Setup with Carthage
+# Setup with Carthage
 * Add ```github "andreamazz/AMPopTip"```
 * Run ```carthage update```
 * Add ```AMPopTip.framework``` in your project
 
-#Usage
+# Usage
 The API is fairly straight forward, you can show and hide the popover at any time.
 
-##Showing the popover
+## Showing the popover
 You must specify the text that you want to display alongside the popover direction, its max width, the view that will contain it and the frame of the view that the popover's arrow will point to.
 
-####Objective-C
+#### Objective-C
 
 ```objc
 self.popTip = [AMPopTip popTip];
 [self.popTip showText:@"I'm a popover popping over" direction:AMPopTipDirectionUp maxWidth:200 inView:self.view fromFrame:someView.frame];
 ```
 
-####Swift
+#### Swift
 
 ```swift
 let popTip = AMPopTip()
@@ -56,13 +56,13 @@ You can also display the popover in the center, with no arrow, in this case the 
 [self.popTip showText:@"I'm a popover" direction:AMPopTipDirectionNone maxWidth:200 inView:self.view fromFrame:self.view.frame];
 ```
 
-##Coordinate system
+## Coordinate system
 Please note that the frame you are intended to provide needs to refer to the absolute coordinate system of the view you are presenting the popover in. This means that if you are presenting the popover in a view, pointing to a nested subview, you'll need to convert its frame using UIKit's `convertRect(_:toView:)`. Read the reference [here](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIView_Class/#//apple_ref/occ/instm/UIView/convertRect:toView:).
 
-##Showing a custom view
+## Showing a custom view
 You can provide a custom view that will be wrapped in the poptip and presented.
 
-####Objective-C
+#### Objective-C
 
 ```objc
 UIView *cutomView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
@@ -70,7 +70,7 @@ UIView *cutomView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
 [self.popTip showCustomView:customView direction:AMPopTipDirectionDown inView:self.view fromFrame:self.view.frame];
 ```
 
-####Swift
+#### Swift
 
 ```swift
 let customView = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
@@ -78,7 +78,7 @@ let customView = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
 popTip.showCustomView(view, direction: .Down, inView: self.view, fromFrame: self.view.frame)
 ```
 
-##Dismissing the popover
+## Dismissing the popover
 You can hide the popover by calling:
 ```objc
 [self.popTip hide];
@@ -111,7 +111,7 @@ self.popTip.dismissHandler = ^{
 };
 ```
 
-#Custom entrance animation
+# Custom entrance animation
 You can choose which animation should be performed when the poptip is displayed:
 ```objc
 self.popTip.entranceAnimation = AMPopTipEntranceAnimationScale;
@@ -124,7 +124,7 @@ AMPopTipEntranceAnimationNone,
 AMPopTipEntranceAnimationCustom
 ```
 
-##AMPopTipEntranceAnimationCustom
+## AMPopTipEntranceAnimationCustom
 You can provide your own animation block when using `AMPopTipEntranceAnimationCustom`:
 ```objc
 self.popTip.entranceAnimation = AMPopTipEntranceAnimationCustom;
@@ -141,7 +141,7 @@ self.popTip.entranceAnimationHandler = ^(void (^completion)(void)){
 ```
 This sample makes the poptip rotate on entrance. Make sure to call the completion block when the animation is done. Also note that the animation is fired as soon as the poptip is added as subview.
 
-#Action animations
+# Action animations
 Action animations are subtle animations that can be performed to get the user's attention. 
 Set your preferred animation:
 ```objc
@@ -158,7 +158,7 @@ The animation is fired as soon as the popover enters the scene and completes its
 
 ![AMPopTip bounce](assets/bounce_effect.gif)
 
-#Customization
+# Customization
 Use the appearance proxy to customize the popover before creating the instance, or just use its public properties:
 ```objc
 AMPopTip *appearance = [AMPopTip appearance];
@@ -190,15 +190,15 @@ appearance.actionDelayOut = <#NSTimeInterval#>;
 appearance.edgeMargin = <#CGFloat#>;
 ```
 
-#Author
+# Author
 [Andrea Mazzini](https://twitter.com/theandreamazz). I'm available for freelance work, feel free to contact me. 
 
 Want to support the development of [these free libraries](https://cocoapods.org/owners/734)? Buy me a coffee ☕️ via [Paypal](https://www.paypal.me/andreamazzini).  
 
-#Contributors
+# Contributors
 Thanks to [everyone](https://github.com/andreamazz/AMPopTip/graphs/contributors) kind enough to submit a pull request. 
 
-#MIT License
+# MIT License
 
 	Copyright (c) 2015 Andrea Mazzini. All rights reserved.
 

--- a/Pods/AMWaveTransition/README.md
+++ b/Pods/AMWaveTransition/README.md
@@ -18,28 +18,28 @@ Read more about transitions [here](http://andreamazz.github.io/blog/2014/04/19/t
   </a>
 </p>
 
-###Screenshot 
+### Screenshot 
 
 ![AMWaveTransition](https://raw.githubusercontent.com/andreamazz/AMWaveTransition/master/assets/screenshot.gif)
 
-#Getting Started
+# Getting Started
 
-##Install with Cocoapods
+## Install with Cocoapods
 
 * Add ```pod 'AMWaveTransition'``` to your [Podfile](http://cocoapods.org/)
 * Run ```pod install```
 * Run ```open App.xcworkspace```
 
-##Install with Carthage
+## Install with Carthage
 ```
 github "andreamazz/AMWaveTransition"
 ```
 
-##Setup as superclass 
+## Setup as superclass 
 
 * Subclass ```AMWaveViewController``` and override ```visibleCells``` or follow these steps:
 
-##Setup manually 
+## Setup manually 
 
 Implement ```UINavigationControllerDelegate``` and this delegate method:
 ```objc
@@ -73,7 +73,7 @@ Implement th ```AMWaveTransitioning``` protocol by returning your tableview's vi
 }
 ```
 
-##Interactive gesture 
+## Interactive gesture 
 
 To implement the interactive gesture create a new property in your view controller:
 ```objc
@@ -100,15 +100,15 @@ If the view controller you are transitioning to has no table view, don't impleme
 
 As you can see in the sample project, the best results are obtained by setting the view and the cells' background to ```clearColor```, and setting a background color or a background image to the navigation controller.
 
-#Author
+# Author
 [Andrea Mazzini](https://twitter.com/theandreamazz). I'm available for freelance work, feel free to contact me. 
 
 Want to support the development of [these free libraries](https://cocoapods.org/owners/734)? Buy me a coffee ☕️ via [Paypal](https://www.paypal.me/andreamazzini).  
 
-#Contributors
+# Contributors
 Thanks to [everyone](https://github.com/andreamazz/AMWaveTransition/graphs/contributors) kind enough to submit a pull request. 
 
-#MIT License
+# MIT License
 
     The MIT License (MIT)
 

--- a/Pods/BAFluidView/README.md
+++ b/Pods/BAFluidView/README.md
@@ -1,4 +1,4 @@
-#BAFluidView
+# BAFluidView
 
 [![CI Status](http://img.shields.io/travis/antiguab/BAFluidView.svg?style=flat)](https://travis-ci.org/antiguab/BAFluidView)
 [![Version](https://img.shields.io/cocoapods/v/BAFluidView.svg?style=flat)](http://cocoadocs.org/docsets/BAFluidView)

--- a/Pods/BubbleTransition/README.md
+++ b/Pods/BubbleTransition/README.md
@@ -38,7 +38,7 @@ pod 'BubbleTransition', git: 'https://github.com/andreamazz/BubbleTransition', b
 use_frameworks!
 ```
 
-#Setup
+# Setup
 Have your viewcontroller conform to `UIViewControllerTransitioningDelegate`. Set the `transitionMode`, the `startingPoint`, the `bubbleColor` and the `duration`.
 ```swift
 let transition = BubbleTransition()
@@ -68,7 +68,7 @@ let transition = BubbleTransition()
 
 You can find the Objective-C equivalent [here](https://gist.github.com/andreamazz/9b0d6c7db065555ec0d7).
 
-#Properties
+# Properties
 ```swift
 var startingPoint = CGPointZero
 ```
@@ -91,15 +91,15 @@ The color of the bubble. Make sure that it matches the destination controller's 
 
 Checkout the sample project for the full implementation.
 
-#Author
+# Author
 [Andrea Mazzini](https://twitter.com/theandreamazz). I'm available for freelance work, feel free to contact me. 
 
 Want to support the development of [these free libraries](https://cocoapods.org/owners/734)? Buy me a coffee ☕️ via [Paypal](https://www.paypal.me/andreamazzini).  
 
-#Contributors
+# Contributors
 Thanks to [everyone](https://github.com/andreamazz/BubbleTransition/graphs/contributors) kind enough to submit a pull request. 
 
-#MIT License
+# MIT License
 
 	Copyright (c) 2015 Andrea Mazzini. All rights reserved.
 

--- a/README.md
+++ b/README.md
@@ -8,29 +8,29 @@ Gulps lets you track your daily water intake in a simple and intuitive way: set 
 
 This app is available in the [AppStore](https://itunes.apple.com/us/app/gulps/id979057304?ls=1&mt=8). Learn more [here](http://www.fancypixel.it/gulps/index.html).
 
-#Description
+# Description
 
 You can learn how to share data between an iOS app and its extension using Realm.  
 
-#Setup
+# Setup
 * Run ```pod install```
 * Run ```open Gulps.xcworkspace```
 * Run `bundle`
 * Run `ruby change_bundle.rb your.bundle.identifier.BigGulp`
 * Match the bundle identifier in `Constants.swift`
 
-#Contribute
+# Contribute
 Want to contribute? We would really appreciate a hand with the localization in other languages. You can find a spreadsheet with all the strings in the project [here](https://docs.google.com/spreadsheets/d/1vh_b1VNcrsiV3mtwOY1V7tW0LR18wHoE1xCMuigc8pg/edit?usp=sharing).  
 
 Feel free to edit the file, we'll include your translation in the next release and attribute your work.  
 
-###Contributors
+### Contributors
 
 - Thanks to [Donny Wals](https://github.com/donnywals) for the Dutch translation. 
 - Thanks to [Alexandre Thomas](https://github.com/thomalexandre) for the French translation. 
 - Thanks to [Durul Dalkanat](https://github.com/durul) for the Turkish translation.
 
-#Imitation is the sincerest form of flattery
+# Imitation is the sincerest form of flattery
 
 That's why we want to thank these fellow developers for the vote of confidence:  
 
@@ -40,7 +40,7 @@ That's why we want to thank these fellow developers for the vote of confidence:
 
 We are ok with that (hence the MIT license), but when cloning this we encourage you to take the [DBAA](http://urbandictionary.com/define.php?term=DBAA) clause in mind. 
 
-#MIT License
+# MIT License
 
 	Copyright (c) 2015 Fancy Pixel S.r.l. All rights reserved.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
